### PR TITLE
Temporarily remove `geovista` from py314 requirements

### DIFF
--- a/lib/iris/tests/integration/experimental/geovista/__init__.py
+++ b/lib/iris/tests/integration/experimental/geovista/__init__.py
@@ -3,3 +3,11 @@
 # This file is part of Iris and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
 """Integration tests for the :mod:`iris.experimental.geovista` module."""
+
+import pytest
+
+# Skip this whole package if geovista (and by extension pyvista) is not available:
+pytest.importorskip(
+    "geovista",
+    reason="Skipping geovista integration tests as `geovista` is not installed",
+)

--- a/lib/iris/tests/unit/experimental/geovista/__init__.py
+++ b/lib/iris/tests/unit/experimental/geovista/__init__.py
@@ -3,3 +3,10 @@
 # This file is part of Iris and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
 """Unit tests for the :mod:`iris.experimental.geovista` module."""
+
+import pytest
+
+# Skip this whole package if geovista (and by extension pyvista) is not available:
+pytest.importorskip(
+    "geovista", reason="Skipping geovista unit tests as `geovista` is not installed"
+)

--- a/requirements/py314.yml
+++ b/requirements/py314.yml
@@ -26,7 +26,7 @@ dependencies:
 
 # Optional dependencies.
   - esmpy >=7.0
-  - geovista
+#  - geovista  # Temporarily removed until pyvista is py3.14 compatible.
   - graphviz
   - iris-sample-data >=2.4.0
   - mo_pack


### PR DESCRIPTION
## 🚀 Pull Request

### Description
The `geovista` optional dependency has been removed from the py314 requirements file until `pyvista` is py3.14 compatible.

To keep the CI running pytests skips have been added at a package level (in the `__init__.py` files) for the `experimental/geovista` unit and integratoin tests.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
